### PR TITLE
Improve the @import regex for collecting files

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -305,9 +305,8 @@ class RenderPreProcessorHook
             $hash = hash('sha1', $hash . $vars);
         } // hash variables too
 
-        preg_match_all('/@import "([^"]*)"/', $content, $imports);
-
-        foreach ($imports[1] as $import) {
+        $imports = $this->collectImports($content);
+        foreach ($imports as $import) {
             $hashImport = '';
 
 
@@ -330,5 +329,29 @@ class RenderPreProcessorHook
         return $hash;
     }
 
+    /**
+     * Collect all @import files in the given content.
+     *
+     * @param string $content
+     * @return array
+     */
+    protected function collectImports(string $content): array
+    {
+        $matches = [];
+        $imports = [];
 
+        preg_match_all('/@import([^;]*);/', $content, $matches);
+
+        foreach ($matches[1] as $importString) {
+            $files = explode(',', $importString);
+
+            array_walk($files, function(string &$file) {
+                $file = trim($file, " \t\n\r\0\x0B'\"");
+            });
+
+            $imports = array_merge($imports, $files);
+        }
+
+        return $imports;
+    }
 }


### PR DESCRIPTION
The regex for collecting imports is improved to handle single or double quotes and imports can be written as one line, separated by comma.

See: https://sass-lang.com/documentation/at-rules/import

```
@import 'foundation';
```
or
```
@import "foundation";
```
or
```
@import 'code', 'lists';
```
or
```
@import
    "abstracts/variables",
    'abstracts/functions';
```

Please have a look at the changes pls and let me know if i should add something 🙂

Best regards,
Andi